### PR TITLE
Make it compile with GCC

### DIFF
--- a/CyLP/cpp/IClpSimplex.cpp
+++ b/CyLP/cpp/IClpSimplex.cpp
@@ -647,8 +647,8 @@ void IClpSimplex::getBasisStatus(int* cstat, int* rstat){
 
 IClpSimplex::IClpSimplex (ClpSimplex * wholeModel,
         int numberColumns, const int * whichColumns)
+ : ClpSimplex(wholeModel, numberColumns, whichColumns)
 {
-    ClpSimplex::ClpSimplex(wholeModel, numberColumns, whichColumns);
     std::cout << "Unfinished constructor called.\n";
     _import_array();
     tempArrayExists = false;

--- a/CyLP/cpp/ICoinMpsIO.cpp
+++ b/CyLP/cpp/ICoinMpsIO.cpp
@@ -186,8 +186,8 @@ int ICoinMpsIO::IreadQuadraticMps(const char * filename, int checkSymmetry){
 	return ret;
 }
 
-ICoinMpsIO::ICoinMpsIO(){
-        CoinMpsIO::CoinMpsIO();
+ICoinMpsIO::ICoinMpsIO() : CoinMpsIO()
+{
 	d_colStart = NULL;
 	d_cols = NULL;
 	d_elements = NULL;

--- a/CyLP/cpp/ICoinPackedMatrix.cpp
+++ b/CyLP/cpp/ICoinPackedMatrix.cpp
@@ -68,9 +68,8 @@ PyObject* ICoinPackedMatrix::np_getVectorStarts(){
 	return Arr;
 }
 
-ICoinPackedMatrix::ICoinPackedMatrix(){
-        CoinPackedMatrix::CoinPackedMatrix();
-}
+ICoinPackedMatrix::ICoinPackedMatrix() : CoinPackedMatrix()
+{}
 
 ICoinPackedMatrix::ICoinPackedMatrix(const bool colordered,
      const int * rowIndices,


### PR DESCRIPTION
Make CyLP compile with GCC.

Actually I doubt the other syntax is valid C++ - you cannot call constructors like functions.
