### PR TITLE
Fix for Properly setting Cbc log level

### DIFF
--- a/cylp/cpp/ICbcModel.cpp
+++ b/cylp/cpp/ICbcModel.cpp
@@ -30,9 +30,11 @@ void ICbcModel::setNodeCompare(PyObject* obj,
 int ICbcModel::cbcMain(){
         // initialize
         int returnCode = -1;
+	int logLevel = this->logLevel();
         CbcMain0(*this);
         const char* argv[] = {"ICbcModel", "-solve","-quit"};
         // Solve ICbcModel and quit
+	this->setLogLevel(logLevel);
         returnCode = CbcMain1 (3, argv, *this);
         return returnCode;
 }


### PR DESCRIPTION
The logLevel parameter is ignored for Cbc models, since it gets reset by CbcMain0. An ugly hack is to cache it before the call and then set it again afterwards.
