### PR TITLE
Fix variable name duplicates

### DIFF
--- a/cylp/py/modeling/CyLPModel.py
+++ b/cylp/py/modeling/CyLPModel.py
@@ -832,13 +832,13 @@ class CyLPModel(object):
         if dim == 0:
             return
         var = CyLPVar(name, dim, isInt)
-        self.variables.append(var)
 
         #If mulidim, correct dim
         if isinstance(dim, tuple):
             dim = reduce(mul, dim)
 
         if not self.inds.hasVar(var.name):
+            self.variables.append(var)
             self.inds.addVar(var.name, dim)
             self.nVars += dim
             self.varNames.append(var.name)


### PR DESCRIPTION
A bug before fix:

> m.addVariable('x', 1)
> m.addVariable('y', 1)
> m.addVariable('x', 1)
> Exception: Varaible x already exists.
> m.variables
> [x, y, x]

this is because the variable is added to the buffer before its name is checked.
