### PR TITLE
Use pkg-config in setup.py; also decode command output.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ except:
     from os.path import abspath, dirname
 
     try:
-        location = dirname(check_output(['which', 'clp']).strip())
+        location = dirname(check_output(['which', 'clp'])
+                           .strip().decode('utf-8'))
         CoinDir = abspath(join(location, ".."))
     except:
         raise Exception('Please set the environment variable COIN_INSTALL_DIR'
@@ -53,15 +54,22 @@ def get_libs():
     '''
     Return a list of distinct library names used by ``dependencies``.
     '''
-    with open(join(CoinDir, 'share', 'coin',
-                   'doc', 'Cbc', 'cbc_addlibs.txt')) as f:
-        link_line = f.read()
-        if operatingSystem == 'windows':
-            libs = [flag[:-4] for flag in link_line.split() if
-                    flag.endswith('.lib')]
-        else:
-            libs = [flag[2:] for flag in link_line.split() if
-                    flag.startswith('-l')]
+    libs = []
+    try:
+        from subprocess import check_output
+        flags = (check_output(['pkg-config', '--libs', 'cbc'])
+                 .strip().decode('utf-8'))
+        libs = [flag[2:] for flag in flags.split() if flag.startswith('-l')]
+    except:
+        with open(join(CoinDir, 'share', 'coin',
+                       'doc', 'Cbc', 'cbc_addlibs.txt')) as f:
+            link_line = f.read()
+            if operatingSystem == 'windows':
+                libs = [flag[:-4] for flag in link_line.split() if
+                        flag.endswith('.lib')]
+            else:
+                libs = [flag[2:] for flag in link_line.split() if
+                        flag.startswith('-l')]
     return libs
 
 def getBdistFriendlyString(s):


### PR DESCRIPTION
Tip: append `?w=1` to the "Files changed" page's URL to make the diff more readable (ignoring whitespace changes).

I encountered two problems with install.py:

1. It requires COIN_INSTALL_DIR to be set, even though it contains code to derive this from the output of `which clp`. This is because the bytes from `subprocess.check_output()` are not decoded, and `os.path.join()` refuses to combine raw bytes with characters, and throws an exception.

2. It tries to open `$COIN_INSTALL_DIR/share/coin/doc/Cbc/cbc_addlibs.txt` - however, this file is not provided with current Ubuntu. Instead, to get the library dependencies on Ubuntu, you have to use the command `pkg-config`. As this is the "modern" way to do it, I have made this the first case.

This patch fixes both problems.