### PR TITLE
CyClpSimplex.pyx: fix memory leak 

### DIFF
--- a/cylp/cy/CyClpSimplex.pyx
+++ b/cylp/cy/CyClpSimplex.pyx
@@ -89,8 +89,8 @@ cdef class CyClpSimplex:
                                 'cylpSimplex constructor. Got %s' %
                                 cyLPModel.__class__)
 
-    #def __dealloc__(self):
-    #    del self.CppSelf
+    def __dealloc__(self):
+        del self.CppSelf
 
     cdef setCppSelf(self,  CppIClpSimplex* s):
         del self.CppSelf


### PR DESCRIPTION
Fixes issue #60 (by uncommenting the `__dealloc__` function, as described by @battery-al and @braginpavel)