### PR TITLE
Switch time.clock() -> time.perf_counter()

### DIFF
--- a/cylp/cy/CyTest.pyx
+++ b/cylp/cy/CyTest.pyx
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import sys
-from time import clock
+from time import perf_counter
 from cylp.cy.CyClpSimplex cimport CyClpSimplex
 from cylp.cy.CyDantzigPivot cimport CyDantzigPivot
 from cylp.cy.CyPEPivot cimport CyPEPivot
@@ -21,7 +21,7 @@ def CySolve(fileName, method):
         ppivot = CyPEPivot(s)
         s.setPrimalColumnPivotAlgorithm(ppivot.CppSelf)
 
-    start = clock()
+    start = perf_counter()
     s.primal()
-    print('Exec time: ',  clock() - start)
+    print('Exec time: ',  perf_counter() - start)
     return s.objectiveValue

--- a/cylp/py/PySolve.py
+++ b/cylp/py/PySolve.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import sys
-from time import clock
+from time import perf_counter
 import cProfile
 import numpy as np
 from cylp.cy import CyClpSimplex
@@ -35,9 +35,9 @@ def solve(filename, method):
 
     #s.setPerturbation(50)
 
-    start = clock()
+    start = perf_counter()
     s.primal()
-    print('Problem solved in %g seconds.' % (clock() - start))
+    print('Problem solved in %g seconds.' % (perf_counter() - start))
     return s.objectiveValue
 
 

--- a/cylp/py/QP/QP.py
+++ b/cylp/py/QP/QP.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import sys
 import cProfile
 import inspect
-from time import clock
+from time import perf_counter
 import numpy as np
 from scipy import sparse
 from cylp.cy import CyClpSimplex
@@ -326,7 +326,7 @@ class QP:
 
     def WolfeEquality(self, method='w'):
         assert(self.nInEquality == 0)
-        start = clock()
+        start = perf_counter()
         A = self.A
         b = CyLPArray(self.b)
         c = CyLPArray(self.c)
@@ -415,10 +415,10 @@ class QP:
         #print('comp list:\n', p.complementarityList)
 
         s.setPivotMethod(p)
-        timeToMake = clock() - start
-        start = clock()
+        timeToMake = perf_counter() - start
+        start = perf_counter()
         s.primal()
-        timeToSolve = clock() - start
+        timeToSolve = perf_counter() - start
 
         self.writeReport('qpout', s, timeToMake, timeToSolve, method, p)
 
@@ -487,13 +487,13 @@ class QP:
 #        #print('comp list:\n', p.complementarityList)
 #
 #        s.setPivotMethod(p)
-##        timeToMake = clock() - start
-##        start = clock()
+##        timeToMake = perf_counter() - start
+##        start = perf_counter()
 #        s.primal()
 
 
 
-#        timeToSolve = clock() - start
+#        timeToSolve = perf_counter() - start
         #s.initialPrimalSolve()
         if method == 'wp':
             total = p.compCount + p.nonCompCount
@@ -872,9 +872,9 @@ class QP:
         p = PositiveEdgeWolfePivot(s, bucketSize=float(sys.argv[2]))
         s.setPivotMethod(p)
 
-        st = clock()
+        st = perf_counter()
         s.primal()
-        print("CLP time : %g seconds" % (clock() - st))
+        print("CLP time : %g seconds" % (perf_counter() - st))
 
         x = s.getPrimalVariableSolution()
         print("sol = ")
@@ -894,7 +894,7 @@ class QP:
         Solves a QP using Wolfe's method (``method = 'w'``) or Wolfe's method using
         positive edge as pivot rule (``method = 'wp'``).
         '''
-        start = clock()
+        start = perf_counter()
         A = self.A
         G = self.G
         b = CyLPArray(self.b)
@@ -1243,10 +1243,10 @@ class QP:
 
         #print(p.complementarityList)
         s.setPivotMethod(p)
-        timeToMake = clock() - start
-        start = clock()
+        timeToMake = perf_counter() - start
+        start = perf_counter()
         s.primal()
-        timeToSolve = clock() - start
+        timeToSolve = perf_counter() - start
         #s.initialPrimalSolve()
         if method == 'wp':
             total = p.compCount + p.nonCompCount
@@ -1598,9 +1598,9 @@ class QP:
         #p = PositiveEdgeWolfePivot(s, bucketSize=float(sys.argv[2]))
         s.setPivotMethod(p)
 
-        st = clock()
+        st = perf_counter()
         s.primal()
-        print("CLP time : %g seconds" % (clock() - st))
+        print("CLP time : %g seconds" % (perf_counter() - st))
 
         x = s.getPrimalVariableSolution()
         print("sol = ")
@@ -1651,7 +1651,7 @@ def getStat():
 
 def QPTest():
     qp = QP()
-    start = clock()
+    start = perf_counter()
     qp.fromQps(sys.argv[1])
     qp.convertToEqualityOnly()
     if len(sys.argv) > 2:
@@ -1659,13 +1659,13 @@ def QPTest():
     else:
         qp.WolfeEquality()
     return
-    r = clock() - start
+    r = perf_counter() - start
     if len(sys.argv) > 2:
         qp.Wolfe(sys.argv[2])
     else:
         qp.Wolfe()
     print('took %g seconds to read the problem' % r)
-    print('took %g seconds to solve the problem' % (clock() - start))
+    print('took %g seconds to solve the problem' % (perf_counter() - start))
     print("done")
 
 import sys


### PR DESCRIPTION
According to https://docs.python.org/3.7/library/time.html#time.clock, the time.clock() function has been deprecated since python 3.3 and was removed in python3.8.

This switches all occurrences of `time.clock()` to `time.perf_counter()` in the Python and Cython code.