### PR TITLE
Close files after opening them

### DIFF
--- a/cylp/__init__.py
+++ b/cylp/__init__.py
@@ -1,4 +1,5 @@
 import os
 from os.path import realpath, join
 currentDir = os.path.dirname(realpath(__file__))
-__version__ = open(join(currentDir, 'VERSION')).read().strip()
+with open(join(currentDir, 'VERSION')) as f:
+    __version__ = f.read().strip()

--- a/cylp/py/QP/QP.py
+++ b/cylp/py/QP/QP.py
@@ -1259,15 +1259,14 @@ class QP:
         qobj = 0.5 * x.T * G * x + np.dot(c, x) - self.objectiveOffset
 
         print(s.iteration)
-        f = open('qpout', 'a')
-        st = '%s %s %s %s %s %s %s\n' % (self.filename.ljust(30), method.ljust(2),
+        with open('qpout', 'a') as f:
+            st = '%s %s %s %s %s %s %s\n' % (self.filename.ljust(30), method.ljust(2),
                 str(round(s.objectiveValue, 5)).ljust(8),
                 str(round(qobj, 5)).ljust(8),
                 str(timeToMake),
                 str(timeToSolve),
                 str(timeToMake + timeToSolve))
-        f.write(st)
-        f.close()
+            f.write(st)
 
 #        print(checkComp(s.primalVariableSolution['k1'],
 #                        s.primalVariableSolution['zk1']))


### PR DESCRIPTION
Using open() as context manager is the preferred way to close files to guarantee exception safety. This commit solves an occasional ResourceWarning, when CylP is used in unit tests run by pytest:

```
>               warnings.warn(pytest.PytestUnraisableExceptionWarning(msg))
E               pytest.PytestUnraisableExceptionWarning: Exception ignored in: <_io.FileIO [closed]>
E               
E               Traceback (most recent call last):
E                 File "/opt/miniconda3/envs/abcvoting/lib/python3.8/site-packages/cylp/__init__.py", line 4, in <module>
E                   __version__ = open(join(currentDir, 'VERSION')).read().strip()
E               ResourceWarning: unclosed file <_io.TextIOWrapper name='/opt/miniconda3/envs/abcvoting/lib/python3.8/site-packages/cylp/VERSION' mode='r' encoding='UTF-8'>

/opt/miniconda3/envs/abcvoting/lib/python3.8/site-packages/_pytest/unraisableexception.py:78: PytestUnraisableExceptionWarning
```

There are more direct calls of open() without context manager in setup.py.

I wasn't able to run the test suite unfortunately, so I couldn't really test the patch... :(