### PR TITLE
Remove outdated self-cimports in pyx files and other Cython 3 prep

### DIFF
--- a/cylp/cy/CyCbcNode.pyx
+++ b/cylp/cy/CyCbcNode.pyx
@@ -1,8 +1,5 @@
 # cython: embedsignature=True
 
-
-cimport CyCbcNode
-
 cdef class CyCbcNode:
     def __cinit__(self):
         self.CppSelf = new CppICbcNode()

--- a/cylp/cy/CyCglCutGeneratorBase.pxd
+++ b/cylp/cy/CyCglCutGeneratorBase.pxd
@@ -16,10 +16,6 @@ cdef extern from "CglCutGenerator.hpp":
     #CppCglCutGenerator* new_CyCglCutGenerator \
     #                                "new ICglCutGenerator" ()
 
-cdef extern from "OsiSolverInterface.hpp":
-    cdef cppclass CppOsiSolverInterface "OsiSolverInterface":
-        pass
-
 cdef extern from "ICglCutGeneratorBase.h":
     #cdef cppclass CoinIndexedVector:
     #   pass

--- a/cylp/cy/CyCglCutGeneratorBase.pyx
+++ b/cylp/cy/CyCglCutGeneratorBase.pyx
@@ -1,8 +1,5 @@
 # cython: embedsignature=True
 
-cimport CyCglCutGeneratorBase
-from cylp.cy.CyCglCutGeneratorBase import CyCglCutGeneratorBase
-
 cdef void RunGenerateCuts(void *ptr, CppOsiSolverInterface *si,
                                      CppOsiCuts *cs,
                                      CppCglTreeInfo info):

--- a/cylp/cy/CyCglTreeInfo.pyx
+++ b/cylp/cy/CyCglTreeInfo.pyx
@@ -1,6 +1,3 @@
-
-cimport CyCglTreeInfo
-
 cdef class CyCglTreeInfo:
     'CyCglTreeInfo documentation'
     def __cinit__(self):

--- a/cylp/cy/CyClpSimplex.pxd
+++ b/cylp/cy/CyClpSimplex.pxd
@@ -304,8 +304,8 @@ cdef class CyClpSimplex:
     This is the documentation of CyClpSimpelx in the pyx class
     '''
 
-    cpdef CppIClpSimplex *CppSelf
-    cpdef vars
+    cdef CppIClpSimplex *CppSelf
+    cdef vars
     cdef object varSelCriteria
     cdef CyCoinModel coinModel
     cdef object cyLPModel

--- a/cylp/cy/CyClpSimplex.pyx
+++ b/cylp/cy/CyClpSimplex.pyx
@@ -15,11 +15,10 @@ import numpy as np
 cimport numpy as np
 from scipy import sparse
 cimport cpython.ref as cpy_ref
-from CyWolfePivot cimport CyWolfePivot
-from CyPEPivot cimport CyPEPivot
-from CyPivotPythonBase cimport CyPivotPythonBase
-from CyDualPivotPythonBase cimport CyDualPivotPythonBase
-from cylp.cy cimport CyClpSimplex
+from cylp.cy.CyWolfePivot cimport CyWolfePivot
+from cylp.cy.CyPEPivot cimport CyPEPivot
+from cylp.cy.CyPivotPythonBase cimport CyPivotPythonBase
+from cylp.cy.CyDualPivotPythonBase cimport CyDualPivotPythonBase
 from cylp.cy cimport CyCoinModel
 from cylp.py.utils.sparseUtil import sparseConcat, csc_matrixPlus
 from cylp.py.modeling.CyLPModel import CyLPVar, CyLPArray, CyLPSolution

--- a/cylp/cy/CyCoinIndexedVector.pxd
+++ b/cylp/cy/CyCoinIndexedVector.pxd
@@ -20,7 +20,7 @@ cdef extern from "ICoinIndexedVector.hpp":
 
 
 cdef class CyCoinIndexedVector:
-    cpdef CppCoinIndexedVector *CppSelf
+    cdef CppCoinIndexedVector *CppSelf
     cpdef reserve(self, n)
     cpdef assign(self, ind, other)
     cdef setCppSelf(self, CppCoinIndexedVector* s)

--- a/cylp/cy/CyCoinModel.pyx
+++ b/cylp/cy/CyCoinModel.pyx
@@ -1,8 +1,5 @@
 # cython: embedsignature=True
 
-
-from cylp.cy cimport CyCoinModel
-
 cdef class CyCoinModel:
     '''
 

--- a/cylp/cy/CyCoinMpsIO.pxd
+++ b/cylp/cy/CyCoinMpsIO.pxd
@@ -45,7 +45,7 @@ cdef extern from "ICoinMpsIO.hpp":
 
 cdef class CyCoinMpsIO:
     cdef CppICoinMpsIO *CppSelf
-    cpdef Hessian
+    cdef Hessian
 #    cpdef  getColLower(self)
 #    cpdef  getColUpper(self)
 #    cpdef getRowSense(self)

--- a/cylp/cy/CyCoinPackedMatrix.pxd
+++ b/cylp/cy/CyCoinPackedMatrix.pxd
@@ -25,7 +25,7 @@ cdef extern from "ICoinPackedMatrix.hpp":
 
 
 cdef class CyCoinPackedMatrix:
-    cpdef CppCoinPackedMatrix* CppSelf
+    cdef CppCoinPackedMatrix* CppSelf
     #cpdef getIndices(self)
     #cpdef getElements(self)
     #cpdef getNumElements(self)

--- a/cylp/cy/CyCutGeneratorPythonBase.pxd
+++ b/cylp/cy/CyCutGeneratorPythonBase.pxd
@@ -1,7 +1,7 @@
-from CyCglCutGeneratorBase cimport *
-from CyOsiSolverInterface cimport CppOsiSolverInterface, CyOsiSolverInterface
-from CyOsiCuts cimport CppOsiCuts, CyOsiCuts
-from CyCglTreeInfo cimport CppCglTreeInfo, CyCglTreeInfo
+from cylp.cy.CyCglCutGeneratorBase cimport *
+from cylp.cy.CyOsiSolverInterface cimport CppOsiSolverInterface, CyOsiSolverInterface
+from cylp.cy.CyOsiCuts cimport CppOsiCuts, CyOsiCuts
+from cylp.cy.CyCglTreeInfo cimport CppCglTreeInfo, CyCglTreeInfo
 cimport cython.operator.dereference as deref
 from cylp.cy.CyClpSimplex cimport CyClpSimplex, CppIClpSimplex
 from cylp.cy.CyCoinIndexedVector cimport CyCoinIndexedVector

--- a/cylp/cy/CyCutGeneratorPythonBase.pyx
+++ b/cylp/cy/CyCutGeneratorPythonBase.pyx
@@ -1,9 +1,5 @@
 # cython: embedsignature=True
 
-
-cimport CyCutGeneratorPythonBase
-
-
 cdef class CyCutGeneratorPythonBase(CyCglCutGeneratorBase):
     def __init__(self, cutGeneratorObject, cyLPModel=None):
         CyCglCutGeneratorBase.__init__(self)

--- a/cylp/cy/CyDantzigPivot.pxd
+++ b/cylp/cy/CyDantzigPivot.pxd
@@ -1,4 +1,4 @@
-from CyClpPrimalColumnPivotBase cimport *
+from cylp.cy.CyClpPrimalColumnPivotBase cimport *
 from cylp.cy cimport CyClpSimplex
 from cylp.cy.CyCoinIndexedVector cimport CyCoinIndexedVector
 

--- a/cylp/cy/CyDantzigPivot.pyx
+++ b/cylp/cy/CyDantzigPivot.pyx
@@ -3,8 +3,6 @@
 
 import numpy as np
 cimport numpy as np
-cimport CyDantzigPivot
-#cimport CyClpSimplex
 
 # varStatus defined to mimic 'enum ClpSimplex::Status'.
 # But is too slow obviously

--- a/cylp/cy/CyDualPivotPythonBase.pxd
+++ b/cylp/cy/CyDualPivotPythonBase.pxd
@@ -1,6 +1,6 @@
 import numpy as np
 cimport numpy as np
-from CyClpDualRowPivotBase cimport *
+from cylp.cy.CyClpDualRowPivotBase cimport *
 cimport cython.operator.dereference as deref
 from cylp.cy cimport CyClpSimplex
 from cylp.cy.CyCoinIndexedVector cimport CyCoinIndexedVector

--- a/cylp/cy/CyDualPivotPythonBase.pyx
+++ b/cylp/cy/CyDualPivotPythonBase.pyx
@@ -1,8 +1,5 @@
 # cython: embedsignature=True
 
-
-cimport CyDualPivotPythonBase
-
 cdef class CyDualPivotPythonBase(CyClpDualRowPivotBase):
     def __init__(self, dualPivotMethodObject):
         CyClpDualRowPivotBase.__init__(self)

--- a/cylp/cy/CyOsiCuts.pyx
+++ b/cylp/cy/CyOsiCuts.pyx
@@ -1,6 +1,5 @@
 import scipy
 from scipy.sparse import csr_matrix
-cimport CyOsiCuts
 from cylp.py.modeling.CyLPModel import CyLPModel
 cimport numpy as np
 import numpy as np

--- a/cylp/cy/CyOsiSolverInterface.pyx
+++ b/cylp/cy/CyOsiSolverInterface.pyx
@@ -1,7 +1,3 @@
-
-cimport CyOsiSolverInterface
-
-
 cdef extern from *:
     CppOsiClpSolverInterface* dynamic_cast_osi_2_clp "dynamic_cast<OsiClpSolverInterface*>" (CppOsiSolverInterface*)
     CppIClpSimplex* static_cast_clp_2_iclp "static_cast<IClpSimplex*>" (CppClpSimplex*)

--- a/cylp/cy/CyPEPivot.pxd
+++ b/cylp/cy/CyPEPivot.pxd
@@ -1,5 +1,5 @@
 cimport cython.operator.dereference as deref
-from CyClpPrimalColumnPivotBase cimport *
+from cylp.cy.CyClpPrimalColumnPivotBase cimport *
 from cylp.cy cimport CyClpSimplex
 from cylp.cy.CyCoinIndexedVector cimport CyCoinIndexedVector
 

--- a/cylp/cy/CyPivotPythonBase.pxd
+++ b/cylp/cy/CyPivotPythonBase.pxd
@@ -1,4 +1,4 @@
-from CyClpPrimalColumnPivotBase cimport *
+from cylp.cy.CyClpPrimalColumnPivotBase cimport *
 cimport cython.operator.dereference as deref
 from cylp.cy.CyClpSimplex cimport CyClpSimplex, CppIClpSimplex
 from cylp.cy.CyCoinIndexedVector cimport CyCoinIndexedVector

--- a/cylp/cy/CyPivotPythonBase.pyx
+++ b/cylp/cy/CyPivotPythonBase.pyx
@@ -1,8 +1,6 @@
 # cython: embedsignature=True
 
 
-cimport CyPivotPythonBase
-
 cdef class CyPivotPythonBase(CyClpPrimalColumnPivotBase):
     def __init__(self, pivotMethodObject):
         CyClpPrimalColumnPivotBase.__init__(self)

--- a/cylp/cy/CyWolfePivot.pxd
+++ b/cylp/cy/CyWolfePivot.pxd
@@ -1,4 +1,4 @@
-from CyClpPrimalColumnPivotBase cimport *
+from cylp.cy.CyClpPrimalColumnPivotBase cimport *
 from cylp.cy cimport CyClpSimplex
 from cylp.cy.CyCoinIndexedVector cimport CyCoinIndexedVector
 

--- a/cylp/cy/CyWolfePivot.pyx
+++ b/cylp/cy/CyWolfePivot.pyx
@@ -1,8 +1,6 @@
 # cython: embedsignature=True
 
 
-from cylp.cy cimport CyWolfePivot
-
 cdef class CyWolfePivot(CyClpPrimalColumnPivotBase):
 
     cdef pivotColumn(self, CppCoinIndexedVector* cppupdates, CppCoinIndexedVector* cppspareRow1,

--- a/cylp/cy/createCythonInterface.py
+++ b/cylp/cy/createCythonInterface.py
@@ -34,7 +34,6 @@ with open(pxdFile, 'w') as f:
 
 #Create the pyx file
 pyxContent = '''
-cimport Cy%s
 
 cdef class Cy%s:
     'Cy%s documentation'


### PR DESCRIPTION
These self-imports from the pxd file are no longer needed (even in Cython 0.29.x).

Also replacing Python-2 style relative cimports with absolute cimports throughout.