### PR TITLE
Switch to Cython 3

### DIFF
--- a/cylp/cy/CyCbcModel.pxd
+++ b/cylp/cy/CyCbcModel.pxd
@@ -10,12 +10,12 @@ cdef extern from "CbcCompareUser.hpp":
     cdef cppclass CppCbcCompareUser "CbcCompareUser":
         pass
     ctypedef int (*runTest_t)(void* instance, CppICbcNode* x,
-                              CppICbcNode* y)
+                              CppICbcNode* y) except? -1
     ctypedef bint (*runNewSolution_t)(void*instance, CppICbcModel* model,
                        double objectiveAtContinuous,
-                       int numberInfeasibilitiesAtContinuous)
+                       int numberInfeasibilitiesAtContinuous) except? -1
     ctypedef int (*runEvery1000Nodes_t)(void* instance,
-                            CppICbcModel* model, int numberNodes)
+                            CppICbcModel* model, int numberNodes) except? -1
     bint equalityTest(CppICbcNode* x, CppICbcNode* y)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   'setuptools',
   'wheel',
-  'Cython < 3',
+  'Cython == 3.0.4',
   # https://numpy.org/devdocs/user/depending_on_numpy.html#build-time-dependency
   # from https://github.com/scipy/oldest-supported-numpy/pull/78#issuecomment-1747936818:
   "oldest-supported-numpy; platform_python_implementation != 'PyPy'",


### PR DESCRIPTION
Adding exception specifications that Cython 3 complains about.

Abandoning Cython 0.29.x, as keeping support for it would require a more complicated change.

Pinning to a specific version for now because the 3.0.x series seems to be in a bit of flux.