### PR TITLE
Update cibuildwheel to 2.17.0, build macos-arm64 wheel on native runners

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -25,7 +25,7 @@ jobs:
             arch: i686
           - os: macos-latest
             arch: auto
-          - os: macos-latest
+          - os: macos-14
             arch: arm64
     env:
       CIBW_ARCHS: ${{ matrix.arch }}
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.17.0
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
@tkralphs This is a possible full solution for #193.

Since early this year, GitHub actually has macOS M1 runners, so we can build the arm64 wheels there