### PR TITLE
Fix leak of CyCoinModel CppSelf

### DIFF
--- a/.github/workflows/ci-cvxpy.yml
+++ b/.github/workflows/ci-cvxpy.yml
@@ -2,7 +2,7 @@ name: Integration testing with CVXPY
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [reopened, opened, synchronize]
   push:
   workflow_dispatch:
 

--- a/cylp/cy/CyCoinModel.pyx
+++ b/cylp/cy/CyCoinModel.pyx
@@ -39,6 +39,9 @@ cdef class CyCoinModel:
     def __cinit__(self):
         self.CppSelf = new CppCoinModel()
 
+    def __dealloc__(self):
+        del self.CppSelf
+
 #   cdef void CLP_addColumn(self, int numberInColumn,
 #                           int * rows,
 #                           double * elements,


### PR DESCRIPTION
CyCoinModel allocates a C++ object `CppSelf` and fails to deallocate it.

A simple test script allocating `CyCoinModel` objects in a loop and deleting them shows significant memory leaked prior to this patch, and negligible memory leaked after (run in a python3.9 docker image):
```python
import gc
import resource
import cylp.cy

def maxrss() -> int:
    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss

print("runs\tmaxrss")
for i in range(10000):
    model = cylp.cy.CyCoinModel()
    del model
    gc.collect()
    if i % 100 == 0:
        print(f"{i}\t{maxrss()}")
```

![mem_usage](https://github.com/coin-or/CyLP/assets/5290430/cd0107c9-d518-44c8-aaca-5357b190b508)