### PR TITLE
Remove hypothesis from requirements

### DIFF
--- a/.github/workflows/ci-cvxpy.yml
+++ b/.github/workflows/ci-cvxpy.yml
@@ -46,5 +46,5 @@ jobs:
 
       - name: Test CVXPY
         run: |
-          python3 -m pip install --break-system-packages pytest
+          python3 -m pip install --break-system-packages pytest hypothesis
           (cd cvxpy/cvxpy/tests && python3 -m pytest -v .)

--- a/.github/workflows/ci-cvxpy.yml
+++ b/.github/workflows/ci-cvxpy.yml
@@ -21,11 +21,28 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+  
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Install CBC
         run: |
           brew install coin-or-tools/coinor/cbc
           echo "PKG_CONFIG_PATH=$(brew --prefix)/opt/cbc/lib/pkgconfig:$(brew --prefix)/opt/clp/lib/pkgconfig:$(brew --prefix)/opt/cgl/lib/pkgconfig:$(brew --prefix)/opt/osi/lib/pkgconfig:$(brew --prefix)/opt/coinutils/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
+      - name: Job context
+        run: |
+          echo "::group::macos context"
+          system_profiler SPSoftwareDataType
+          echo "::endgroup::"
+
+          python -V
+
+          echo "::group::brew cbc info"
+          brew info coin-or-tools/coinor/cbc
+          echo "::endgroup::"
+          
       - uses: actions/checkout@v2
         with:
           path: cylp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires = [
   # from https://github.com/scipy/oldest-supported-numpy/pull/78#issuecomment-1747936818:
   "oldest-supported-numpy; platform_python_implementation != 'PyPy'",
   "numpy < 2.0.0; platform_python_implementation=='PyPy'",
-  'hypothesis'
 ]
 build-backend = "setuptools.build_meta"
 
@@ -27,3 +26,4 @@ before-all = """
 """
 environment = { PATH="$(pwd)/local/bin:$PATH", LD_LIBRARY_PATH="$(pwd)/local/lib:$LD_LIBRARY_PATH", PKG_CONFIG_PATH="$(pwd)/local/lib/pkgconfig:$PKG_CONFIG_PATH", CIBW_ARCHS="$CIBW_ARCHS" }
 skip = ["pp*-macosx*", "*-musllinux*", "pp31*-*", "pp*-*i686", "pp38-manylinux*", "pp39-manylinux*", "cp312-*i686", "cp313-*"]
+test-requires = ["cvxpy[testing]"]

--- a/setup.py
+++ b/setup.py
@@ -414,6 +414,6 @@ setup(name='cylp',
                 'cylp.py.utils', 'cylp.py.mip','cylp.py.QP'],
       cmdclass={'build_ext': build_ext},
       ext_modules=ext_modules,
-      install_requires=['numpy >= 1.5.0,<2.0.0', 'scipy >= 0.10.0', 'hypothesis'],
+      install_requires=['numpy >= 1.5.0,<2.0.0', 'scipy >= 0.10.0'],
       zip_safe = False,
       package_data={"cylp": extra_files})


### PR DESCRIPTION
This was introduced in #202 as a stop-gap measure. Hypothesis is used by the cvxpy test suite, so only install hypothesis in the CI when building wheels (via `cibuildwheel`) and when running the cvxpy integration tests.

Fixes #209
