### PR TITLE
Add runtime (install) dependencies on numpy and scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ authors=[
   {  name = 'Dominique Orban', email = 'dominique.orban@gerad.ca' },
   {  name =  'Ted Ralphs', email = 'ted@lehigh.edu'  }
 ]
+dependencies = [
+  "numpy",
+  "scipy",
+]
 license='EPL-2.0'
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ authors=[
   {  name =  'Ted Ralphs', email = 'ted@lehigh.edu'  }
 ]
 dependencies = [
-  "numpy",
-  "scipy",
+  "numpy >= 1.26.0",
+  "scipy >= 0.10.0",
 ]
 license='EPL-2.0'
 


### PR DESCRIPTION
We already have `numpy` as a *build* dependency,

https://github.com/coin-or/CyLP/blob/9520c5b42d11b06b42c2522bf7f0135d03de36f3/pyproject.toml#L21

but very many of CyLP’s APIs rely on `numpy`, and quite a few also require `scipy`.

It seems like these both ought to be hard runtime/install-time dependencies, as proposed in this PR. This would avoid experiences like the following:

```
$ python3 -m venv _e
$ . _e/bin/activate
(_e) $ pip install cylp
(_e) $ python -c 'from cylp.py.modeling import CyLPVar'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    from cylp.py.modeling import CyLPVar
  File "/home/ben/tmp/_e/lib64/python3.13/site-packages/cylp/py/__init__.py", line 1, in <module>
    from . import pivots
  File "/home/ben/tmp/_e/lib64/python3.13/site-packages/cylp/py/pivots/__init__.py", line 1, in <module>
    from .DantzigPivot import DantzigPivot
  File "/home/ben/tmp/_e/lib64/python3.13/site-packages/cylp/py/pivots/DantzigPivot.py", line 8, in <module>
    import numpy as np
ModuleNotFoundError: No module named 'numpy'
(_e) $ pip install numpy
(_e) $ python -c 'from cylp.py.modeling import CyLPVar'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    from cylp.py.modeling import CyLPVar
  File "/home/ben/tmp/_e/lib64/python3.13/site-packages/cylp/py/__init__.py", line 1, in <module>
    from . import pivots
  File "/home/ben/tmp/_e/lib64/python3.13/site-packages/cylp/py/pivots/__init__.py", line 3, in <module>
    from .PositiveEdgePivot import PositiveEdgePivot
  File "/home/ben/tmp/_e/lib64/python3.13/site-packages/cylp/py/pivots/PositiveEdgePivot.py", line 8, in <module>
    from cylp.cy import CyCoinIndexedVector
  File "/home/ben/tmp/_e/lib64/python3.13/site-packages/cylp/cy/__init__.py", line 2, in <module>
    from .CyClpSimplex import CyClpSimplex
  File "cylp/cy/CyClpSimplex.pyx", line 1, in init cylp.cy.CyClpSimplex
  File "cylp/cy/CyClpPrimalColumnPivotBase.pyx", line 1, in init cylp.cy.CyClpPrimalColumnPivotBase
  File "cylp/cy/CyClpDualRowPivotBase.pyx", line 1, in init cylp.cy.CyClpDualRowPivotBase
  File "cylp/cy/CyOsiSolverInterface.pyx", line 1, in init cylp.cy.CyOsiSolverInterface
  File "cylp/cy/CyCbcModel.pyx", line 1, in init cylp.cy.CyCbcModel
  File "cylp/cy/CyOsiCuts.pyx", line 1, in init cylp.cy.CyOsiCuts
ModuleNotFoundError: No module named 'scipy'
(_e) $ pip install scipy
(_e) $ python -c 'from cylp.py.modeling import CyLPVar'
[succeeds quietly]
```