### PR TITLE
Fix a mismatch between format string and number of values

### DIFF
--- a/cylp/cy/createCythonInterface.py
+++ b/cylp/cy/createCythonInterface.py
@@ -44,7 +44,7 @@ cdef class Cy%s:
         del self.CppSelf
         self.CppSelf = s
 
-''' % (className, className, className, className, className)
+''' % (className, className, className, className)
 
 with open(pyxFile, 'w') as f:
     f.write(pyxContent)


### PR DESCRIPTION
One `%s` was removed from the format string in 615a193296ffa0bcf4a56739d68a589618022cce, but the tuple was not adjusted to match.