### PR TITLE
Update GH Actions macOS runner, update cibuildwheel for Python 3.14 build, add support for Cython 3.1.x, 3.2.x

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -30,7 +30,7 @@ jobs:
             arch: i686
           - os: ubuntu-24.04-arm
             arch: aarch64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64
           - os: macos-latest
             arch: arm64

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v3.2.1
 
       - uses: actions/upload-artifact@v4
         with:

--- a/cylp/cy/CyClpSimplex.pyx
+++ b/cylp/cy/CyClpSimplex.pyx
@@ -1022,7 +1022,7 @@ cdef class CyClpSimplex:
 
         '''
         status = CLP_variableStatusEnum[StatusToInt[status]]
-        if isinstance(arg, (int, long)):
+        if isinstance(arg, int):
             self.CppSelf.setStatus(arg, status)
         elif True:  # isinstance(arg, CyLPVar):
             if self.cyLPModel is None:
@@ -1047,7 +1047,7 @@ cdef class CyClpSimplex:
         '''
         Get the status of a variable.
         '''
-        if isinstance(arg, (int, long)):
+        if isinstance(arg, int):
             return IntToStatus[self.CppSelf.getStatus(arg)]
         elif True:  # isinstance(arg, CyLPVar):
             if self.cyLPModel is None:
@@ -1096,7 +1096,7 @@ cdef class CyClpSimplex:
         'atLowerBound'
         '''
         status = CLP_variableStatusEnum[StatusToInt[status]]
-        if isinstance(arg, (int, long)):
+        if isinstance(arg, int):
             arg += self.nVariables
             self.CppSelf.setStatus(arg, status)
         elif True:  # isinstance(arg, CyLPVar):
@@ -1118,7 +1118,7 @@ cdef class CyClpSimplex:
         '''
         Get the status of a constraint.
         '''
-        if isinstance(arg, (int, long)):
+        if isinstance(arg, int):
             arg += self.nVariables
             return IntToStatus[self.CppSelf.getStatus(arg)]
         elif True:  # isinstance(arg, CyLPVar):
@@ -1718,7 +1718,7 @@ cdef class CyClpSimplex:
 
         '''
 
-        if isinstance(arg, (int, long)):
+        if isinstance(arg, int):
             self.CppSelf.setInteger(arg)
         elif True:  # isinstance(arg, CyLPVar):
             if self.cyLPModel is None:
@@ -2088,7 +2088,7 @@ cdef class CyClpSimplex:
         arguments may be integers signifying indices, or CyLPVars.
         '''
 
-        if isinstance(var1, (int, long)) and isinstance(var2, (int, long)) :
+        if isinstance(var1, int) and isinstance(var2, int) :
            self.CppSelf.setComplement(var1, var2)
         elif True:  # isinstance(arg, CyLPVar):
             if self.cyLPModel is None:

--- a/cylp/py/mip/GomoryCutGenerator.py
+++ b/cylp/py/mip/GomoryCutGenerator.py
@@ -12,7 +12,7 @@ def isInt(x):
     Return True if x is an integer, or if x is a numpy array
     with all integer elements, False otherwise
     '''
-    if isinstance(x, (int, long, float)):
+    if isinstance(x, (int, float)):
         return abs(math.floor(x) - x) < epsilon
     return (np.abs(np.floor(x) - x) < epsilon).all()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ Documentation="https://coin-or.github.io/CyLP"
 [build-system]
 requires = [
   'setuptools',
-  'Cython == 3.0.10',
+  'Cython>=3.0.10, <3.2',
   'numpy>=2.0.0rc1',
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ Documentation="https://coin-or.github.io/CyLP"
 [build-system]
 requires = [
   'setuptools',
-  'Cython>=3.0.10, <3.2',
+  'Cython>=3.0.10, <3.3',
   'numpy>=2.0.0rc1',
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The `macos-13` runners are deprecated and will disappear by end of 2025. Replacement: `macos-15-intel`.